### PR TITLE
fix(transitions): Avoid panicking on helper functions with no transition

### DIFF
--- a/smak.go
+++ b/smak.go
@@ -98,6 +98,10 @@ func edges(b *builder) []edge {
 
 func transitionNames(b *builder, node *ast.ReturnStmt) []string {
 	var dst []string
+	if len(node.Results) < 1 {
+		// Not a real transition function, could be an helper func.
+		return dst
+	}
 	switch tr := node.Results[0].(type) {
 	case *ast.Ident:
 		dst = []string{tr.Name}


### PR DESCRIPTION
If you had helper function in your state machine, it was wrongly checking for results causing a panic in smak

```
$ smak -state-fn stateFn -out edges ./my/state/folder/
panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
main.transitionNames(0x459bd8?, 0x0?)
        C:/Users/padelisle/go/pkg/mod/rmazur.io/smak@v0.0.1/smak.go:101 +0x20d
main.edges(0xc00017dbc0)
        C:/Users/padelisle/go/pkg/mod/rmazur.io/smak@v0.0.1/smak.go:87 +0x10a
main.main()
        C:/Users/padelisle/go/pkg/mod/rmazur.io/smak@v0.0.1/smak.go:38 +0x245
```
